### PR TITLE
Add source version to javadoc config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
 						<artifactId>maven-javadoc-plugin</artifactId>
 						<version>3.5.0</version>
 						<configuration>
+							<source>1.8</source>
 							<quiet>true</quiet>
 							<notimestamp>true</notimestamp>
 							<doclint>all,-missing</doclint>


### PR DESCRIPTION
Test if this will fix these warnings

> Warning: [WARNING] javadoc: warning - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/8/docs/api/ are in the unnamed module.