### PR TITLE
Fix publish_dir name and update gh-pages actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
       run: mvn javadoc:javadoc
 
     - name: Deploy docs
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./target/report/apidocs
+        publish_dir: ./target/reports/apidocs

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
 						<artifactId>maven-javadoc-plugin</artifactId>
 						<version>3.5.0</version>
 						<configuration>
+							<source>11</source>
 							<quiet>true</quiet>
 							<notimestamp>true</notimestamp>
 							<doclint>all,-missing</doclint>


### PR DESCRIPTION
- Fix publish_dir name (`report` -> `reports`)
- Update peaceiris/actions-gh-pages to v4
- Use Java 11 for Javadoc to avoid unnamed modules warning (Java 8 does not has modules).