### PR TITLE
Update source/target to 11 LTS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,8 +244,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>9</source>
-					<target>9</target>
+					<source>11</source>
+					<target>11</target>
 					<encoding>${project.build.sourceEncoding}</encoding>
 					<showDeprecation>true</showDeprecation>
 					<showWarnings>true</showWarnings>


### PR DESCRIPTION
9 and 10 not LTS and supports ended since September 2018, had few issues with dependencies when building javadoc